### PR TITLE
pull for small fix

### DIFF
--- a/src/turtle/player/dirchooser/DirChooser.java
+++ b/src/turtle/player/dirchooser/DirChooser.java
@@ -115,7 +115,11 @@ public class DirChooser extends Activity
     }
 
     private void setAdapterForDir(File file){
-        ArrayAdapter<File> adapter = new FileAdapter(this, file.listFiles());
+        File [] files = file.listFiles();
+        if (files == null) {
+            files = new File[0];
+        }
+        ArrayAdapter<File> adapter = new FileAdapter(this, files);
         dirList.setAdapter(adapter);
     }
 }


### PR DESCRIPTION
Player unexpectedly crashes on editing library path if no sd card is set. Was trying to set up player on emulator
