### PR TITLE
Avoid db rescan on startup

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -35,8 +35,6 @@
     <string name="library">Library</string>
     <string name="rescan">Re-Scan SD Card</string>
 
-    <string name="pref_previously_started">firstTime</string>
-
     <string name="dirchooser_label">Dir Chooser</string>
 
 </resources>

--- a/src/turtle/player/Database.java
+++ b/src/turtle/player/Database.java
@@ -203,35 +203,6 @@ public class Database extends SQLiteOpenHelper
 			return false;
 		}
 	}
-
-	
-	public boolean Exists()
-	{
-		SQLiteDatabase check = null;
-		
-		try
-		{
-			check = SQLiteDatabase.openDatabase("/data/data/hnd.turtle.player/databases/TurtlePlayer", null, SQLiteDatabase.OPEN_READONLY);
-		}
-		catch (SQLiteException e)
-		{
-			// No Database
-		}finally {
-            if(check != null)
-            {
-                check.close();
-            }
-        }
-		
-		if (check != null)
-		{
-			return true;
-		}
-		else
-		{
-			return false;
-		}
-	}
 	
 	public int BooleanToInt(boolean val)
 	{

--- a/src/turtle/player/Playlist.java
+++ b/src/turtle/player/Playlist.java
@@ -219,11 +219,10 @@ public class Playlist {
                 }
 
                 ClearList();
-                //syncDB.Clear();
 
                 try {
                     // TODO EXISTS BUT MAYBE BLANK!?!
-                    if (!syncDB.Exists() || syncDB.IsEmpty()) {
+                    if (syncDB.IsEmpty()) {
                         try {
                             final File mediaPath = preferences.GetMediaPath();
 
@@ -823,22 +822,13 @@ public class Playlist {
 	
 	public void DatabasePush()
 	{
-		if (syncDB.Exists())
-		{
-			syncDB.Clear();
-			syncDB.Push(trackList);
-		}
+        syncDB.Clear();
+        syncDB.Push(trackList);
 	}
 	
 	public void DatabasePull()
 	{
-	    boolean previouslyStarted =
-                SharedPreferencesAccess.getValue(preferences.getContext(), Keys.FIRST_TIME);
-	    if(!previouslyStarted)
-	    {
-            SharedPreferencesAccess.putValue(preferences.getContext(), Keys.FIRST_TIME, true);
-			trackList = syncDB.Pull();
-	    }
+        trackList = syncDB.Pull();
 	}
 	
 	public void DatabaseClear()

--- a/src/turtle/player/preferences/Keys.java
+++ b/src/turtle/player/preferences/Keys.java
@@ -2,7 +2,6 @@ package turtle.player.preferences;
 
 public abstract class Keys{
 
-    public final static Key<Boolean> FIRST_TIME = new Key<Boolean>("firstTime", false);
     public final static Key<Boolean> SHUFFLE = new Key<Boolean>("firstTime", false);
     public final static Key<Boolean> REPEAT = new Key<Boolean>("firstTime", false);
     public final static Key<String> MEDIA_DIR = new Key<String>("mediaDir", "/sdcard/Music/");


### PR DESCRIPTION
Method Exists seems not to work and is not really necessary. so recan on sturtup if db is empty. (db gets autocreated if not existing)
