### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-#[Turtle Player](http://www.turtle-player.co.uk/ "Turtle Player")
+# [Turtle Player](http://www.turtle-player.co.uk/ "Turtle Player")
 
 <img src="http://www.turtle-player.co.uk/img/logo-medium.png" alt="" align="left" />
 
-###Free, Fully Fledged & Open-Source. The Music Player for Android.
+### Free, Fully Fledged & Open-Source. The Music Player for Android.
 
 Turtle Player is designed to be a fun and unique app for playing your music on the move, while in a advertisment-free app. Originally developed by Edd Turtle, it is now a community driven app with help from developers (namely Simon Honegger) on Github. Give it a go today!
 
-#####*Warning! Due to other commitments I haven't had the time to maintain and keep this project up-to-date. It should work fine on modern android phones, but the visuals and code are bit old - that's all.*
+##### *Warning! Due to other commitments I haven't had the time to maintain and keep this project up-to-date. It should work fine on modern android phones, but the visuals and code are bit old - that's all.*
 
-##How to Contribute
+## How to Contribute
 
 1) First, pull the source code from this git repository to your local machine:
 
@@ -27,7 +27,7 @@ Turtle Player is designed to be a fun and unique app for playing your music on t
 
 6) Create a Pull Request back to this repository.
 
-###License 
+### License 
 Source is licenced under the [MIT](http://www.opensource.org/licenses/mit-license.php "MIT License") & [GPL](http://www.gnu.org/copyleft/gpl.html "General Public License").
 
   [1]: http://www.turtle-player.co.uk/img/logo-medium.png


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
